### PR TITLE
Support a custom requestId generation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,25 @@ $ node example.js | pino
 
 ### pinoHttp([options], [stream])
 
-`pino-http` has the same options as [pino](http://npm.im/pino).
+#### options
 
+`pino-http` has the same options as [pino](http://npm.im/pino).
 `pino-http` attaches listeners to the request, in order to log when the request completes
 
+##### logger
+
 `pino-http` can reuse a pino instance if passed with the `logger`
-property:
+property
+
+##### genReqId
+
+You can pass a `genReqId` function which gets used to generate a request id. The first argument is the request itself.
+
+As fallback `pino-http` is just using an integer. This default might not be the desired behavior if you're running multiple instances of the app.
+
+#### Examples
+
+##### Logger options
 
 ```js
 'use strict'
@@ -105,7 +118,17 @@ var http = require('http')
 var server = http.createServer(handle)
 var pino = require('pino')()
 var logger = require('pino-http')({
-  logger: pino
+  // Reuse an existing logger instance
+  logger: pino,
+
+  // Define a custom request id function
+  genReqId: function (req) { return req.id },
+
+  // Define custom serializers
+  serializers: {
+    req: pino.stdSerializers.req,
+    res: pino.stdSerializers.res
+  }
 })
 
 function handle (req, res) {
@@ -117,19 +140,8 @@ function handle (req, res) {
 server.listen(3000)
 ```
 
-Example:
 
-```js
-'use strict'
-
-var pino = require('pino-http')
-var logger = pino({
-  serializers: {
-    req: pino.stdSerializers.req,
-    res: pino.stdSerializers.res
-  }
-})
-```
+#### Default serializers
 
 ### pinoHttp.stdSerializers.req
 
@@ -160,7 +172,7 @@ It returns an object in the form:
 }
 ```
 
-### pinoHttp.stdSerializers.res
+##### pinoHttp.stdSerializers.res
 
 Generates a JSONifiable object from the HTTP `response` object passed to
 the `createServer` callback of Node's HTTP server.

--- a/test.js
+++ b/test.js
@@ -84,6 +84,29 @@ test('allocate a unique id to every request', function (t) {
   })
 })
 
+test('uses a custom genReqId function', function (t) {
+  t.plan(4)
+
+  var dest = split(JSON.parse)
+  var idToTest
+  function genReqId (req) {
+    t.ok(req.url, 'The first argument must be the request parameter')
+    idToTest = (Date.now() + Math.random()).toString(32)
+    return idToTest
+  }
+
+  var logger = pinoHttp({genReqId: genReqId}, dest)
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  dest.on('data', function (line) {
+    t.equal(typeof line.req.id, 'string')
+    t.equal(line.req.id, idToTest)
+  })
+})
+
 test('reuses existing req.id if present', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
This adds a `opts.genReqId` option that can be a function that returns a custom request id.

@mcollina Did you have something like this in mind?

Tests are still missing